### PR TITLE
Trim coverage report

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -38,10 +38,17 @@ jobs:
       - run: |
           make test
 
+      - run: |
+          head -1 cover.out > nucleus_cover.out
+          grep 'governance-policy-nucleus' cover.out >> nucleus_cover.out
+          go tool cover -func=nucleus_cover.out
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
+
       - name: Update coverage report
         uses: ncruces/go-coverage-report@v0
         with:
-          coverage-file: cover.out
+          coverage-file: nucleus_cover.out
           report: true
           chart: false
           amend: false


### PR DESCRIPTION
It's not clear why, but in the action run, the coverage report included a lot of dependencies. This grep might work.