### PR TITLE
More toolkit utilities

### DIFF
--- a/api/v1beta1/target.go
+++ b/api/v1beta1/target.go
@@ -16,15 +16,15 @@ import (
 type Target struct {
 	*metav1.LabelSelector `json:",inline"`
 
+	// Namespace is the namespace to restrict the Target to. Can be empty for non-namespaced
+	// objects, or to look in all namespaces.
+	Namespace string `json:"namespace,omitempty"`
+
 	// Include is a list of filepath expressions to include objects by name.
 	Include []NonEmptyString `json:"include,omitempty"`
 
 	// Exclude is a list of filepath expressions to include objects by name.
 	Exclude []NonEmptyString `json:"exclude,omitempty"`
-
-	// Namespace is the namespace to restrict the Target to. Can be empty for non-namespaced
-	// objects, or to look in all namespaces.
-	Namespace string `json:"namespace,omitempty"`
 }
 
 //+kubebuilder:object:generate=false

--- a/pkg/testutils/courtesies.go
+++ b/pkg/testutils/courtesies.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,4 +49,20 @@ func EventFilter(events []corev1.Event, evType, msg string, since time.Time) []c
 	}
 
 	return ans
+}
+
+// RegisterDebugMessage returns a pointer to a string which will be logged at the
+// end of the test only if the test fails. This is particularly useful for logging
+// information only once in an Eventually or Consistently function.
+// Note: using a custom description message may be a better practice overall.
+func RegisterDebugMessage() *string {
+	var debugMsg string
+
+	ginkgo.DeferCleanup(func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			ginkgo.GinkgoWriter.Println(debugMsg)
+		}
+	})
+
+	return &debugMsg
 }

--- a/test/fakepolicy/api/v1beta1/fakepolicy_types.go
+++ b/test/fakepolicy/api/v1beta1/fakepolicy_types.go
@@ -15,15 +15,15 @@ type FakePolicySpec struct {
 	// TargetConfigMaps defines the ConfigMaps which should be examined by this policy
 	TargetConfigMaps nucleusv1beta1.Target `json:"targetConfigMaps,omitempty"`
 
-	// TargetUsingReflection defines whether to use reflection to find the ConfigMaps
-	TargetUsingReflection bool `json:"targetUsingReflection,omitempty"`
-
 	// DesiredConfigMapName - if this name is not found, the policy will report a violation
 	DesiredConfigMapName string `json:"desiredConfigMapName,omitempty"`
 
 	// EventAnnotation - if provided, this value will be annotated on the compliance
 	// events, under the "policy.open-cluster-management.io/test" key
 	EventAnnotation string `json:"eventAnnotation,omitempty"`
+
+	// TargetUsingReflection defines whether to use reflection to find the ConfigMaps
+	TargetUsingReflection bool `json:"targetUsingReflection,omitempty"`
 }
 
 //+kubebuilder:validation:Optional

--- a/test/fakepolicy/test/basic/namespaceselection_test.go
+++ b/test/fakepolicy/test/basic/namespaceselection_test.go
@@ -36,7 +36,7 @@ var _ = Describe("FakePolicy NamespaceSelection", Ordered, func() {
 		// constructing the default / allNamespaces lists is complicated because of how ginkgo
 		// runs the table tests... this seems better than other workarounds.
 		nsList := corev1.NamespaceList{}
-		Expect(k8sClient.List(ctx, &nsList)).To(Succeed())
+		Expect(tk.List(ctx, &nsList)).To(Succeed())
 
 		foundNS := make([]string, len(nsList.Items))
 		for i, ns := range nsList.Items {
@@ -57,7 +57,7 @@ var _ = Describe("FakePolicy NamespaceSelection", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				foundPolicy := fakev1beta1.FakePolicy{}
-				g.Expect(k8sClient.Get(ctx, testutils.ObjNN(&policy), &foundPolicy)).To(Succeed())
+				g.Expect(tk.Get(ctx, testutils.ObjNN(&policy), &foundPolicy)).To(Succeed())
 				g.Expect(foundPolicy.Status.SelectionComplete).To(BeTrue())
 
 				idx, cond := foundPolicy.Status.GetCondition("NamespaceSelection")

--- a/test/fakepolicy/test/basic/suite_test.go
+++ b/test/fakepolicy/test/basic/suite_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/onsi/gomega/format"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -26,12 +25,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
-	tk        testutils.Toolkit
+	cfg     *rest.Config
+	testEnv *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
+	tk      testutils.Toolkit
 )
 
 //nolint:paralleltest // scaffolded this way by ginkgo
@@ -67,12 +65,9 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	tk, err = testutils.NewToolkitFromRest(cfg, "")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	tk = testutils.NewToolkit(k8sClient)
-	tk.BackgroundCtx = ctx
+	tk = tk.WithCtx(ctx)
 
 	go func() {
 		defer GinkgoRecover()

--- a/test/fakepolicy/test/basic/target_test.go
+++ b/test/fakepolicy/test/basic/target_test.go
@@ -53,7 +53,7 @@ var _ = Describe("FakePolicy TargetConfigMaps", func() {
 		// constructing the default / allConfigMaps lists is complicated because of how ginkgo
 		// runs the table tests... this seems better than other workarounds.
 		cmList := corev1.ConfigMapList{}
-		Expect(k8sClient.List(ctx, &cmList)).To(Succeed())
+		Expect(tk.List(ctx, &cmList)).To(Succeed())
 
 		foundCM := make([]string, len(cmList.Items))
 		for i, cm := range cmList.Items {
@@ -138,7 +138,7 @@ var _ = Describe("FakePolicy TargetConfigMaps", func() {
 	checkFunc := func(policy fakev1beta1.FakePolicy, desiredMatches []string, selErr string) func(g Gomega) {
 		return func(g Gomega) {
 			foundPolicy := fakev1beta1.FakePolicy{}
-			g.Expect(k8sClient.Get(ctx, testutils.ObjNN(&policy), &foundPolicy)).To(Succeed())
+			g.Expect(tk.Get(ctx, testutils.ObjNN(&policy), &foundPolicy)).To(Succeed())
 			g.Expect(foundPolicy.Status.SelectionComplete).To(BeTrue())
 
 			slices.Sort(desiredMatches)

--- a/test/fakepolicy/test/basic/toolkit_test.go
+++ b/test/fakepolicy/test/basic/toolkit_test.go
@@ -1,0 +1,35 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package basic
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Additional Toolkit tests", func() {
+	It("Config methods should override values, but preserve the original toolkit", func() {
+		newTK := tk.
+			WithEPoll("50ms").
+			WithETimeout("3s").
+			WithCPoll("500ms").
+			WithCTimeout("2s")
+
+		Expect(newTK.EventuallyPoll).To(Equal("50ms"))
+		Expect(newTK.EventuallyTimeout).To(Equal("3s"))
+		Expect(newTK.ConsistentlyPoll).To(Equal("500ms"))
+		Expect(newTK.ConsistentlyTimeout).To(Equal("2s"))
+
+		Expect(tk.EventuallyPoll).To(Equal("100ms"))
+		Expect(tk.EventuallyTimeout).To(Equal("1s"))
+		Expect(tk.ConsistentlyPoll).To(Equal("100ms"))
+		Expect(tk.ConsistentlyTimeout).To(Equal("1s"))
+	})
+
+	It("Kubectl should return error outputs", func() {
+		output, err := tk.Kubectl("get", "node", "nonexist")
+		Expect(output).To(BeEmpty())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+})

--- a/test/fakepolicy/test/compliance/suite_test.go
+++ b/test/fakepolicy/test/compliance/suite_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/onsi/gomega/format"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -26,12 +25,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
-	tk        testutils.Toolkit
+	cfg     *rest.Config
+	testEnv *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
+	tk      testutils.Toolkit
 )
 
 //nolint:paralleltest // scaffolded this way by ginkgo
@@ -64,12 +62,9 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	tk, err = testutils.NewToolkitFromRest(cfg, "")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	tk = testutils.NewToolkit(k8sClient)
-	tk.BackgroundCtx = ctx
+	tk = tk.WithCtx(ctx)
 
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
The main addition is `.Kubectl`, which seems to be slower than using the client directly, but can be more ergonomic for development. This requires a kubeconfig, but one can be generated from the REST config, only requiring small changes to the main "constructor" function for a toolkit.